### PR TITLE
fix: Correct missing icon import for Admin Documentation link

### DIFF
--- a/src/components/layout/admin-layout.tsx
+++ b/src/components/layout/admin-layout.tsx
@@ -2,7 +2,7 @@
 
 import React, { ReactNode } from 'react';
 import Link from 'next/link';
-import { LayoutDashboard, Users, Settings, BarChart } from 'lucide-react'; // Example icons
+import { LayoutDashboard, Users, Settings, BarChart, BookText } from 'lucide-react'; // Added BookText
 
 interface AdminLayoutProps {
   children: ReactNode;


### PR DESCRIPTION
Corrected a bug in `src/components/layout/admin-layout.tsx` where the `BookText` icon for the "Documentation" navigation link was not imported.

This missing import would cause a runtime error, preventing the link from rendering correctly and potentially breaking the admin sidebar, making the `/admin/documentation` page inaccessible via the UI.

The import has been added, ensuring the icon and link render as expected, restoring access to the Admin Documentation page.